### PR TITLE
Fix faulty readline bind in shell_automatic_cd.sh

### DIFF
--- a/examples/shell_automatic_cd.sh
+++ b/examples/shell_automatic_cd.sh
@@ -20,4 +20,4 @@ ranger_cd() {
 }
 
 # This binds Ctrl-O to ranger-cd:
-bind '"\C-o":"ranger-cd\C-m"'
+bind '"\C-o":"ranger_cd\C-m"'


### PR DESCRIPTION
#### ISSUE TYPE
- Bug fix

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux
- Terminal emulator and version: (bash 5.0.18)
- Python version: (irrelevant)
- Ranger version/commit: 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [ ] All new and existing tests pass **[REQUIRED]**

#### DESCRIPTION
<!-- Describe the changes in detail -->
In the example script "shell_automatic_cd.sh" Ctrl+O is bound to ranger-cd, which does not exist.

#### TESTING
No testing was done since no changes to the ranger code were made.